### PR TITLE
Corrected 'Text file' to 'Terminal'

### DIFF
--- a/Index - Basic.ipynb
+++ b/Index - Basic.ipynb
@@ -169,7 +169,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.5.1"
+   "version": "3.4.3"
   },
   "livereveal": {
    "height": 768,

--- a/examples/Notebook/Notebook Basics.ipynb
+++ b/examples/Notebook/Notebook Basics.ipynb
@@ -229,7 +229,7 @@
    "source": [
     "If the notebook server is run on an operating system which supports [PTY](https://en.wikipedia.org/wiki/Pseudoterminal) (Linux/Mac), then the notebook application will be able to spawn interactive terminal instances. If the operating system does not support PTY (Windows), the terminal feature will not be enabled.\n",
     "\n",
-    "A new terminal can be spawned from the dashboard by clicking on the **`Files`** tab, followed by the **`New`** dropdown button, and then selecting **`Text File`**.\n",
+    "A new terminal can be spawned from the dashboard by clicking on the **`Files`** tab, followed by the **`New`** dropdown button, and then selecting **`Terminal`**.\n",
     "\n",
     "The terminal supports all applications which would otherwise run in a PTY, this includes classical terminal applications like Vim, Nano, and Bash.\n",
     "\n",
@@ -254,7 +254,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.5.1"
+   "version": "3.4.3"
   },
   "widgets": {
    "state": {},


### PR DESCRIPTION
 in 'basic notebook' file there is an explanation for terminal use in jupyter that points the user to open Text files, I just changed that to 'Terminal'. :)

Thanks for the great tutorial!
